### PR TITLE
bnotify 1.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![bnotify](http://i.imgur.com/GDWvTpp.png)](#)
 
-# `$ bnotify` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/bnotify.svg)](https://www.npmjs.com/package/bnotify) [![Downloads](https://img.shields.io/npm/dt/bnotify.svg)](https://www.npmjs.com/package/bnotify) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# `$ bnotify`
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/bnotify.svg)](https://www.npmjs.com/package/bnotify) [![Downloads](https://img.shields.io/npm/dt/bnotify.svg)](https://www.npmjs.com/package/bnotify) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > A notification system written in NodeJS using the BAT platform.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnotify",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A notification system written in NodeJS using the BAT platform.",
   "main": "lib/index.js",
   "bin": {
@@ -82,6 +82,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ],


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
